### PR TITLE
Update Atom.jss.recipe

### DIFF
--- a/Atom.jss.recipe
+++ b/Atom.jss.recipe
@@ -31,7 +31,7 @@
         <key>MinimumVersion</key>
         <string>0.4.0</string>
         <key>ParentRecipe</key>
-        <string>io.github.hjuutilainen.pkg.Atom</string>
+        <string>io.github.hjuutilainen.download.Atom</string>
         <key>Process</key>
         <array>
             <dict>


### PR DESCRIPTION
When running autopkg, says no valid recipe found for Atom.jss. Looks like hjuutilainen's Atom ParentRecipe changed